### PR TITLE
Cleanup option database (for mail.ru driver)

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func main() {
 			Aliases: []string{"dsn"},
 			Usage:   "clickhouse connection string, see https://github.com/mailru/go-clickhouse#dsn",
 			EnvVars: []string{"CH_FLAME_CLICKHOUSE_DSN"},
-			Value:   "http://localhost:8123?database=default",
+			Value:   "http://localhost:8123/default",
 		},
 		&cli.StringFlag{
 			Name:    "clickhouse-cluster",


### PR DESCRIPTION
Database default passed as http://127.0.0.1:8123/default
